### PR TITLE
Notes and code from hack the house

### DIFF
--- a/hack_the_house/README.md
+++ b/hack_the_house/README.md
@@ -1,0 +1,9 @@
+# Hack the House
+
+## Particle Photon
+
+- We attached a couple of sensors to a photon to detect motion/changes
+- Firmware to do this can be found in `led_motion_sensor.ino`
+- Documentation is at [docs.particle.io](https://docs.particle.io/guide/getting-started/intro/photon/)
+- Firmware can be flashed to the photon via the particle web IDE at [build.photon.io](https://build.particle.io/)
+- Photon can be claimed, setup, or have its wifi configured with the [particle cli](https://github.com/spark/particle-cli)

--- a/hack_the_house/led_motion_sensor.ino
+++ b/hack_the_house/led_motion_sensor.ino
@@ -1,0 +1,39 @@
+int pir = D1; // PIR sensor is at D1
+int mag = D3; // magnet sensor is at D3;
+
+int buzzer = D5; // buzzer is at D5
+
+int green = D0; // green LED is at D0
+int red = D4; // red LED is at D4
+
+void setup()
+{
+  pinMode(pir, INPUT); // PIR is waiting for input
+  pinMode(mag, INPUT); // magnet is waiting for input
+
+  pinMode(buzzer, OUTPUT);  // buzzer is producing output
+
+  pinMode(green, OUTPUT); // green LED is producing output
+  pinMode(red, OUTPUT); // red LED is producing output
+}
+
+void loop() {
+  // set the green LED to be in the same state as the PIR sensor (when sensor detects motion it is HIGH, HIGH for LED means on)
+  digitalWrite(green, digitalRead(pir));
+
+  // set the red LED to be in the same state as the magnet sensor (when sensor parts are pulled apart the signal is HIGH, HIGH for LED means on)
+  digitalWrite(red, digitalRead(mag));
+
+  // if the input from the magnet sensor is LOW (i.e., the parts are together), set the buzzer to LOW (off)
+  if (digitalRead(mag) == LOW) {
+    digitalWrite(buzzer, LOW);
+  }
+
+  // if the input from the magnet sensor is HIGH (i.e., the parts are apart), set the buzzer to HIGH (on)
+  if (digitalRead(mag) == HIGH) {
+    Particle.publish("door-open"); // publish an empty event called "door-open"
+
+    delay(5000); // ring the sound for 5 seconds
+    digitalWrite(buzzer, HIGH);
+  }
+}


### PR DESCRIPTION
This is the firmware for the motion sensor/magnet sensor/led setup from hack the house Nov 11-13 and some notes about setting it up and where we found resources.

Next steps for this are:
- making it work with the thermocouple temperature sensor that came with the maker kit (we were not able to get meaningful readings from it)
- fix the `delay(5000)` call. We want to sound the buzzer after the magnet sensor has been apart for more than 5 seconds, but the problem with `delay` is that it freezes all other execution while it finishes.. so if someone pulls the magnet sensor apart for 5 seconds, the buzzer goes off, then they put the sensor back together, the buzzer will still ring for at least 5 seconds. The language has a `millis()` function that returns the number of seconds since the device booted that I was trying to use to manage the timing instead of `delay` 